### PR TITLE
Swap deprecated np.int to int

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name="sfdmap",
                            "Topic :: Scientific/Engineering :: Astronomy",
                            "Intended Audience :: Science/Research"],
             py_modules=["sfdmap"],
-            install_requires=["numpy"],
+            install_requires=["numpy", "astropy", ],
             url="http://github.com/kbarbary/sfdmap",
             author="Kyle Barbary",
             author_email="kylebarbary@gmail.com")

--- a/sfdmap.py
+++ b/sfdmap.py
@@ -24,7 +24,7 @@ except ImportError:
 
 
 __all__ = ['SFDMap', 'ebv']
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def _isiterable(obj):

--- a/sfdmap.py
+++ b/sfdmap.py
@@ -122,9 +122,9 @@ def _bilinear_interpolate(data, y, x):
     xw = x - xfloor
 
     # pixel locations
-    y0 = yfloor.astype(np.int)
+    y0 = yfloor.astype(int)
     y1 = y0 + 1
-    x0 = xfloor.astype(np.int)
+    x0 = xfloor.astype(int)
     x1 = x0 + 1
 
     # clip locations out of range
@@ -167,8 +167,8 @@ class _Hemisphere(object):
         if interpolate:
             return _bilinear_interpolate(self.data, y, x)
         else:
-            x = np.round(x).astype(np.int)
-            y = np.round(y).astype(np.int)
+            x = np.round(x).astype(int)
+            y = np.round(y).astype(int)
 
             # some valid coordinates are right on the border (e.g., x/y = 4096)
             x = np.clip(x, 0, self.data.shape[1]-1)


### PR DESCRIPTION
Since numpy v1.20, the use of aliases such as `np.int` have been deprecated (see e.g https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations). The recommended solution is to instead use`int`, which is equivalent. This PR replaces for four instances of `np.int` in `sfdmap.py` with `int`.

When I run the unit tests, I would previously get 38 warnings with numpy v1.22, but now get none.